### PR TITLE
Add RV32A and RV64A instruction.

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -133,6 +133,34 @@ pub enum Instruction {
     Fcvtswu(RType),
     Fmvwx(RType),
 
+    // RV32A Standard Extension
+    AmoswapW(RType),
+    AmoaddW(RType),
+    AmoxorW(RType),
+    AmoandW(RType),
+    AmoorW(RType),
+    AmominW(RType),
+    AmomaxW(RType),
+    AmominuW(RType),
+    AmomaxuW(RType),
+
+    LrW(RType),
+    ScW(RType),
+
+    // RV64A Standard Extension
+    AmoswapD(RType),
+    AmoaddD(RType),
+    AmoxorD(RType),
+    AmoandD(RType),
+    AmoorD(RType),
+    AmominD(RType),
+    AmomaxD(RType),
+    AmominuD(RType),
+    AmomaxuD(RType),
+
+    LrD(RType),
+    ScD(RType),
+
     // Illegal
     Illegal,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -299,7 +299,6 @@ mod tests {
         assert_eq!(IType(0x0007b703).imm(), 0); // Ld x14,0(x15)
     }
 
-
     #[test]
     #[allow(overflowing_literals)]
     fn btype() {
@@ -308,7 +307,10 @@ mod tests {
         assert_eq!(BType(0x06f58063).imm(), 0x80002648 - 0x800025e8); // beq x11,x15,80002648
         assert_eq!(BType(0x00050a63).imm(), 0x800024e8 - 0x800024d4); // beq x10,x0,800024e8
         assert_eq!(BType(0x03ff0663).imm(), 0x80000040 - 0x80000014); // beq x30,x31,80000040
-        assert_eq!(BType(0xfe069ae3).imm(), (0x800026f0i32 - 0x800026fci32) as u32 & 0x1fff); // bne x13,x0,800026f0
+        assert_eq!(
+            BType(0xfe069ae3).imm(),
+            (0x800026f0i32 - 0x800026fci32) as u32 & 0x1fff
+        ); // bne x13,x0,800026f0
         assert_eq!(BType(0x00f5f463).imm(), 0x80002290 - 0x80002288); // bgeu x11,x15,80002290
         assert_eq!(BType(0x1e301c63).imm(), 0x800003c4 - 0x800001cc); // bne x0,x3,800003c4
         assert_eq!(BType(0x13df1063).imm(), 0x800030dc - 0x80002fbc); // bne x30,x29,800030dc
@@ -335,14 +337,26 @@ mod tests {
     #[test]
     #[allow(overflowing_literals)]
     fn jtype() {
-        assert_eq!(JType(0xfe1ff06f).imm(), (0x800029eci32 - 0x80002a0ci32) as u32 & 0x1fffff); // jal x0,800029ec
+        assert_eq!(
+            JType(0xfe1ff06f).imm(),
+            (0x800029eci32 - 0x80002a0ci32) as u32 & 0x1fffff
+        ); // jal x0,800029ec
         assert_eq!(JType(0x0000006f).imm(), 0x80002258 - 0x80002258); // jal x0,80002258
-        assert_eq!(JType(0xf89ff06f).imm(), (0x800027aci32 - 0x80002824i32)  as u32 & 0x1fffff); // jal x0,800027ac
+        assert_eq!(
+            JType(0xf89ff06f).imm(),
+            (0x800027aci32 - 0x80002824i32) as u32 & 0x1fffff
+        ); // jal x0,800027ac
         assert_eq!(JType(0x0240006f).imm(), 0x8000215c - 0x80002138); // jal x0,8000215c
-        assert_eq!(JType(0xd89ff0ef).imm(), (0x80002230i32 - 0x800024a8i32) as u32 & 0x1fffff); // jal x1,80002230
+        assert_eq!(
+            JType(0xd89ff0ef).imm(),
+            (0x80002230i32 - 0x800024a8i32) as u32 & 0x1fffff
+        ); // jal x1,80002230
         assert_eq!(JType(0x008007ef).imm(), 0x8000265c - 0x80002654); // jal x15,8000265c
         assert_eq!(JType(0x0240006f).imm(), 0x80002154 - 0x80002130); // jal x0,80002154
-        assert_eq!(JType(0xf71ff06f).imm(), (0x80002750i32 - 0x800027e0i32) as u32 & 0x1fffff); // jal x0,80002750
+        assert_eq!(
+            JType(0xf71ff06f).imm(),
+            (0x80002750i32 - 0x800027e0i32) as u32 & 0x1fffff
+        ); // jal x0,80002750
         assert_eq!(JType(0x00c0006f).imm(), 0x8000000c - 0x80000000); // jal x0,8000000c
 
         assert_eq!(JType(0xfe1ff06f).rd(), 0); // jal x0,800029ec


### PR DESCRIPTION
Added support for RV32A and RV64A instruction, and added test cases.
Also I ran cargo fmt so the formatting was modified.

Here are the test results：
```
running 22 tests
test tests::amo ... ok
test compressed::tests::q00 ... ok
test tests::branch ... ok
test tests::float ... ok
test tests::decoding ... ok
test tests::load ... ok
test tests::misc_mem ... ok
test tests::op ... ok
test tests::op32 ... ok
test tests::op_imm ... ok
test tests::op_imm32 ... ok
test tests::store ... ok
test tests::system ... ok
test types::tests::btype ... ok
test types::tests::csritype ... ok
test types::tests::csrtype ... ok
test types::tests::fencetype ... ok
test types::tests::itype ... ok
test types::tests::jtype ... ok
test types::tests::rtype ... ok
test types::tests::shifttype ... ok
test types::tests::utype ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests riscv_decode

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
