### PR TITLE
Add `sdsp` compress instruction support

### DIFF
--- a/src/compressed.rs
+++ b/src/compressed.rs
@@ -50,8 +50,38 @@ pub fn decode_q01(_i: u32) -> DecodingResult {
     Err(DecodingError::Unimplemented)
 }
 
-pub fn decode_q10(_i: u32) -> DecodingResult {
-    Err(DecodingError::Unimplemented)
+pub fn decode_q10(i: u32) -> DecodingResult {
+    match i >> 13 {
+        0b110 => {
+            let imm = (i >> 7) & 0b111111;
+            let rs2 = (i >> 2) & 0b11111;
+            let offset_1 = imm & 0b11111;
+            let offset_2 = (imm >> 5) & 0b1;
+            Ok(Instruction::Sb(SType(
+                0b0100011 | // func [0: 6]
+                offset_1 << 7 | // [7: 11]
+                0b000 << 12 | // [12: 14]
+                (0x2 << 15) | // rs1 sp [15: 19]
+                (rs2 << 20) | // rs2 [20: 24]
+                offset_2 << 25
+            )))
+        }
+        0b111 => {
+            let imm = (i >> 7) & 0b111111;
+            let rs2 = (i >> 2) & 0b11111;
+            let offset_1 = ((imm >> 3) & 0b11) << 3;
+            let offset_2 = ((imm >> 5) & 0b1) | ((imm & 0b111) << 1);
+            Ok(Instruction::Sd(SType(
+                0b0100011 | // func [0: 6]
+                offset_1 << 7 | // [7: 11]
+                0b011 << 12 | // [12: 14]
+                (0x2 << 15) | // rs1 sp [15: 19]
+                (rs2 << 20) | // rs2 [20: 24]
+                offset_2 << 25
+            )))
+        }
+        _ => Err(DecodingError::Unimplemented)
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,11 @@ mod tests {
     //
     // $ rg "\tbne\t" | sort -R | tail -n 3 | xclip -selection c
 
+    #[test] 
+    fn sdsp() {
+        assert_eq!(decode(0x0000e486).unwrap(), Sd(SType(0x0420b423)));
+    }
+
     #[test]
     fn decoding() {
         assert_eq!(decode(0x00001a37).unwrap(), Lui(UType(0x00001a37))); // lui x20,0x1


### PR DESCRIPTION
Dear @fintelia , first of all, thank you very much for creating the riscv-decode project, which has helped us a lot in building our RISC-V VMM project.

Our team ([@arceos-hypervisor](https://github.com/arceos-hypervisor)) has been exploiting the `sdsp` instruction while developing the RISC-V VMM, and we previously forked it into our third-party dependencies. We're planning to release the [arceos-hypervisor/axvisor](https://github.com/arceos-hypervisor/axvisor) project to **crates.io**, so we'd like to merge our code for `sdsp` instruction decode support into the mainline. We appreciate your support!

cc @aarkegz