### PR TITLE
Fix decoding of c.swsp and test for c.sdsp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,11 +351,6 @@ mod tests {
     //
     // $ rg "\tbne\t" | sort -R | tail -n 3 | xclip -selection c
 
-    #[test] 
-    fn sdsp() {
-        assert_eq!(decode(0x0000e486).unwrap(), Sd(SType(0x0420b423)));
-    }
-
     #[test]
     fn decoding() {
         assert_eq!(decode(0x00001a37).unwrap(), Lui(UType(0x00001a37))); // lui x20,0x1


### PR DESCRIPTION
To generate the tests, I ran `objdump -d libz.so.1.3.1  | rg 'sw.*sp'` against a randomly selected RISC-V binary (specifically a copy of libz.so from [here](https://packages.debian.org/sid/riscv64/zlib1g/download)). Then I ran the disassembled instructions through [an assembler](https://riscvasm.lucasteske.dev) that didn't know know about compressed instructions, to produce the equivalent 32-bit instructions.

I also corrected the decoding of the quadrant `10` compressed instruction with opcode `110`: it should be c.swsp. As far as I can tell, there is no compressed sb instruction.